### PR TITLE
Reduce size of the produced CentOS image by 50%

### DIFF
--- a/centos-6.5/Dockerfile
+++ b/centos-6.5/Dockerfile
@@ -2,15 +2,6 @@ FROM tianon/centos:6.5
 MAINTAINER SequenceIQ
 
 ADD Centos-Source.repo /etc/yum.repos.d/Centos-Source.repo
+ADD build.sh /tmp/build.sh
 
-RUN yum update -y
-
-RUN yum install -y tar bzip2 yum-utils rpm-build
-
-RUN yum-builddep -y pam
-RUN yumdownloader --source pam
-RUN rpmbuild --rebuild  --define 'WITH_AUDIT 0' --define 'dist +noaudit' pam*.src.rpm
-RUN rpm -Uvh --oldpackage ~/rpmbuild/RPMS/*/pam*+noaudit*.rpm
-
-RUN rm -f /*.rpm
-RUN rm -rf ~/rpmbuild
+RUN sh /tmp/build.sh && rm -f /tmp/build.sh

--- a/centos-6.5/build.sh
+++ b/centos-6.5/build.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+errorExit() {
+	echo "*** $*" 1>&2
+	exit 1
+}
+
+yum clean metadata || errorExit "Error cleaning yum metadata."
+yum update -y || errorExit "Error yum-updating."
+rpm -qa >/tmp/old-rpms.lst
+yum install -y tar bzip2 yum-utils rpm-build || errorExit "Error installing dependencies."
+
+yum-builddep -y pam || errorExit "Error in yum-builddep."
+yumdownloader --source pam || errorExit "Error downloading sources."
+
+export RPM_BUILD_NCPUS=`nproc`
+rpmbuild --rebuild  --define 'WITH_AUDIT 0' --define 'dist +noaudit' pam*.src.rpm || errorExit "Error rebuilding."
+
+TO_REMOVE=""
+for i in `rpm -qa`; do
+	if ! grep -q "^${i}$" /tmp/old-rpms.lst; then
+		TO_REMOVE="$TO_REMOVE $i"
+	fi
+done
+echo "Removing `echo $TO_REMOVE | wc -w` unneeded packages."
+yum remove -y $TO_REMOVE || errorExit "Error removing unneeded software."
+
+if [ `rpm -qa | wc -l` -ne `cat /tmp/old-rpms.lst | wc -l` ]; then
+	errorExit "Error, we've got inconsistent packages, `rpm -qa | wc -l` instead of `cat /tmp/old-rpms.lst | wc -l`."
+fi
+
+rpm -Uvh --oldpackage ~/rpmbuild/RPMS/*/pam*+noaudit*.rpm || errorExit "Error installing newly built PAM rpms."
+
+yum clean all
+rm -f /*.rpm
+rm -rf ~/rpmbuild
+rm -f /tmp/old-rpms.lst


### PR DESCRIPTION
Docker build fine tuning: move RUN statements into a single shell script, leading to only one RUN in the Dockerfile and thus only one internal layer. Also clean up more thoroughly. As a result the image created has only half the size of what it was before.
